### PR TITLE
feat: Export normalized price of vcpu and memory

### DIFF
--- a/exporter/instances.go
+++ b/exporter/instances.go
@@ -1,0 +1,65 @@
+package exporter
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// AWS doesn’t share the relationship between CPU and memory for each instance type, therefore we get this info from GCP.
+	// Obviously, it could be some differences between the cpu/memory relationship between the cloud providers but using the GCP
+	// relationship could give us a fairly approximate global idea and allow us know the cost of our pods and namespaces.
+
+	// To simplify operations and taking into account an approximate global idea would be accepted the CPU-Memory relationship is
+	// calculated as:
+
+	// CPU-cost = 7.2 memory-GB-cost
+
+	// https://engineering.empathy.co/cloud-finops-part-4-kubernetes-cost-report/
+	cpuMemRelation = 7.2
+)
+
+func (e *Exporter) getInstances() {
+	e.instances = make(map[string]Instance)
+	ec2Svc := ec2.NewFromConfig(e.awsCfg)
+	pag := ec2.NewDescribeInstanceTypesPaginator(
+		ec2Svc,
+		&ec2.DescribeInstanceTypesInput{})
+	for pag.HasMorePages() {
+		instances, err := pag.NextPage(context.TODO())
+		if err != nil {
+			log.WithError(err).Errorf("error while fetching available instance types")
+			atomic.AddUint64(&e.errorCount, 1)
+			break
+		}
+		for _, instance := range instances.InstanceTypes {
+			e.instances[string(instance.InstanceType)] = Instance{
+				Memory: aws.ToInt64(instance.MemoryInfo.SizeInMiB),
+				VCpu:   aws.ToInt32(instance.VCpuInfo.DefaultVCpus),
+			}
+		}
+	}
+}
+
+func (e Exporter) getInstanceMemory(instance string) string {
+	return strconv.Itoa(int(e.instances[instance].Memory))
+}
+
+func (e Exporter) getInstanceVCpu(instance string) string {
+	return strconv.Itoa(int(e.instances[instance].VCpu))
+}
+
+func (e Exporter) getNormalizedCost(value float64, instance string) (float64, float64) {
+	vcpu := e.instances[instance].VCpu
+	memory := e.instances[instance].Memory / 1024
+
+	memoryCost := value / (cpuMemRelation*float64(vcpu) + float64(memory))
+	vcpuCost := cpuMemRelation * memoryCost
+
+	return vcpuCost, memoryCost
+}

--- a/exporter/types.go
+++ b/exporter/types.go
@@ -33,3 +33,8 @@ type Details struct {
 	BeginRange   string
 	PricePerUnit map[string]string
 }
+
+type Instance struct {
+	Memory int64
+	VCpu   int32
+}

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 func main() {
-	log.Infof("Starting AWS EC2 Price exporter. [log-level=%s, product-descriptions=%s, operating-systems=%s, cache=%d]", *rawLevel, *productDescriptions, *operatingSystems, *cache)
+	log.Infof("Starting AWS EC2 Price exporter. [log-level=%s, product-descriptions=%s, operating-systems=%s, cache=%d, lifecycle=%s]", *rawLevel, *productDescriptions, *operatingSystems, *cache, *lifecycle)
 
 	var reg []string
 	if len(*regions) == 0 {
@@ -64,9 +64,13 @@ func main() {
 
 	pds := splitAndTrim(*productDescriptions)
 	oss := splitAndTrim(*operatingSystems)
+	lc := splitAndTrim(*lifecycle)
+	if len(lc) == 0 {
+		lc = []string{"spot", "ondemand"}
+	}
 	validateProductDesc(pds)
 	validateOperatingSystems(oss)
-	exporter, err := exporter.NewExporter(pds, oss, reg, *cache)
+	exporter, err := exporter.NewExporter(pds, oss, reg, lc, *cache)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Export the normalized cost of vcpu and memory (GB) per instance type, this allows us to slice the cost of the instance by each running application (e.g. useful to estimate the cost of each kubernetes pod)

```
$ curl -s  localhost:8080/metrics | grep aws | grep m5.large | grep 1a
aws_pricing_ec2{availability_zone="sa-east-1a",instance_lifecycle="ondemand",instance_type="m5.large",memory="8192",operating_system="Linux",product_description="",region="sa-east-1",vcpu="2"} 0.153
aws_pricing_ec2{availability_zone="sa-east-1a",instance_lifecycle="spot",instance_type="m5.large",memory="8192",operating_system="",product_description="Linux/UNIX",region="sa-east-1",vcpu="2"} 0.0528
aws_pricing_ec2_memory{availability_zone="sa-east-1a",instance_lifecycle="ondemand",instance_type="m5.large",region="sa-east-1"} 0.006830357142857143
aws_pricing_ec2_memory{availability_zone="sa-east-1a",instance_lifecycle="spot",instance_type="m5.large",region="sa-east-1"} 0.002357142857142857
aws_pricing_ec2_vcpu{availability_zone="sa-east-1a",instance_lifecycle="ondemand",instance_type="m5.large",region="sa-east-1"} 0.04917857142857143
aws_pricing_ec2_vcpu{availability_zone="sa-east-1a",instance_lifecycle="spot",instance_type="m5.large",region="sa-east-1"} 0.01697142857142857
```